### PR TITLE
Tajik

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## What is CyrTranslit?
 A Python package for bi-directional transliteration of Cyrillic script text into Roman alphabet text and vice versa.
 
-By default, transliterates for the Serbian language. A language flag can be set in order to transliterate to and from Macedonian, Montenegrin, and Russian.
+By default, transliterates for the Serbian language. A language flag can be set in order to transliterate to and from Macedonian, Montenegrin, Tajik and Russian.
 
 ## What is transliteration?
 Transliteration is the conversion of a text from one script to another. For instance, a Roman alphabet transliteration of the Serbian phrase "Република Косово" is "Republika Kosovo".
@@ -15,11 +15,11 @@ python -m pip install cyrtranslit>=0.4	# minimum version
 ```
 
 ## What languages are supported?
-CyrTranslit currently supports bi-directional transliteration of Montenegrin, Serbian, Macedonian, and Russian:
+CyrTranslit currently supports bi-directional transliteration of Montenegrin, Serbian, Macedonian, Tajik and Russian:
 ```python
 >>> import cyrtranslit
 >>> cyrtranslit.supported()
-['me', 'sr', 'mk', 'ru']
+['me', 'sr', 'mk', 'ru', 'tj']
 ```
 ## How do I use this? 
 ### Serbian
@@ -54,6 +54,16 @@ CyrTranslit currently supports bi-directional transliteration of Montenegrin, Se
 >>> cyrtranslit.to_cyrillic('Moyo sudno na vozdushnoj podushke polno ugrej', 'ru')
 'Моё судно на воздушной подушке полно угрей'
 ```
+
+### Tajik
+```python
+>>> import cyrtranslit
+>>> cyrtranslit.to_latin('Ман мактуб навишта истодам', 'tj')
+'Man maktub navišta istodam'
+>>> cyrtranslit.to_cyrillic('Man maktub navišta istodam', 'tj')
+'Ман мактуб навишта истодам'
+```
+
 
 ## How can I contribute?
 You can include support for other Cyrillic script alphabets. Follow these steps in order to do so:

--- a/cyrtranslit/mapping.py
+++ b/cyrtranslit/mapping.py
@@ -134,10 +134,31 @@ RU_LAT_TO_CYR_DICT.update({
     u"iy": u"ый",  # dobriy => добрый
 })
 
-# Transliterate from tajik cyrillic to latin
+# Transliterate from Tajik cyrillic to latin
 TJ_CYR_TO_LAT_DICT = copy.deepcopy(RU_CYR_TO_LAT_DICT)
-TJ_CYR_TO_LAT_DICT[u"Э"] = u"E"
-TJ_CYR_TO_LAT_DICT[u"э"] = u"e"
+# Change Mapping according to ISO 9 (1995)
+TJ_CYR_TO_LAT_DICT[u"Э"] = u"È"
+TJ_CYR_TO_LAT_DICT[u"э"] = u"è"
+TJ_CYR_TO_LAT_DICT[u"ъ"] = u"’"
+TJ_CYR_TO_LAT_DICT[u"Ч"] = u"Č"
+TJ_CYR_TO_LAT_DICT[u"ч"] = u"č"
+TJ_CYR_TO_LAT_DICT[u"Ж"] = u"Ž"
+TJ_CYR_TO_LAT_DICT[u"ж"] = u"ž"
+TJ_CYR_TO_LAT_DICT[u"Ё"] = u"Ë"
+TJ_CYR_TO_LAT_DICT[u"ё"] = u"ë"
+TJ_CYR_TO_LAT_DICT[u"Ш"] = u"Š"
+TJ_CYR_TO_LAT_DICT[u"ш"] = u"š"
+TJ_CYR_TO_LAT_DICT[u"Ю"] = u"Û"
+TJ_CYR_TO_LAT_DICT[u"ю"] = u"û"
+TJ_CYR_TO_LAT_DICT[u"Я"] = u"Â"
+TJ_CYR_TO_LAT_DICT[u"я"] = u"â"
+# delete letters not used 
+del TJ_CYR_TO_LAT_DICT[u"Ц"]
+del TJ_CYR_TO_LAT_DICT[u"ц"]
+del TJ_CYR_TO_LAT_DICT[u"Щ"]
+del TJ_CYR_TO_LAT_DICT[u"щ"]
+del TJ_CYR_TO_LAT_DICT[u"Ы"]
+del TJ_CYR_TO_LAT_DICT[u"ы"]
 
 # update the dict for the additional letters in the tajik cyrillic alphabet ( Ғ, Ӣ, Қ, Ӯ, Ҳ, Ҷ )
 # see https://en.wikipedia.org/wiki/Tajik_alphabet#Cyrillic
@@ -146,15 +167,12 @@ TJ_CYR_TO_LAT_DICT.update({
     u"Ӣ": u"Ī", u"ӣ": u"ī", 
     u"Қ": u"Q", u"қ": u"q", 
     u"Ӯ": u"Ū", u"ӯ": u"ū",
-    u"Ҳ": u"H", u"ҳ": u"h",
+    u"Ҳ": u"Ḩ", u"ҳ": u"ḩ",
     u"Ҷ": u"Ç", u"ҷ": u"ç"
 })
 
 # transliterate from latin tajik to cyrillic
 TJ_LAT_TO_CYR_DICT = {y: x for x, y in iter(TJ_CYR_TO_LAT_DICT.items())}
-
-# care for latin digraphs
-#TJ_LAT_TO_CYR_DICT.update(RU_LAT_TO_CYR_DICT)
 
 # Bundle up all the dictionaries in a lookup dictionary
 TRANSLIT_DICT = {

--- a/cyrtranslit/mapping.py
+++ b/cyrtranslit/mapping.py
@@ -134,6 +134,28 @@ RU_LAT_TO_CYR_DICT.update({
     u"iy": u"ый",  # dobriy => добрый
 })
 
+# Transliterate from tajik cyrillic to latin
+TJ_CYR_TO_LAT_DICT = copy.deepcopy(RU_CYR_TO_LAT_DICT)
+TJ_CYR_TO_LAT_DICT[u"Э"] = u"E"
+TJ_CYR_TO_LAT_DICT[u"э"] = u"e"
+
+# update the dict for the additional letters in the tajik cyrillic alphabet ( Ғ, Ӣ, Қ, Ӯ, Ҳ, Ҷ )
+# see https://en.wikipedia.org/wiki/Tajik_alphabet#Cyrillic
+TJ_CYR_TO_LAT_DICT.update({
+    u"Ғ": u"Ǧ", u"ғ": u"ǧ",
+    u"Ӣ": u"Ī", u"ӣ": u"ī", 
+    u"Қ": u"Q", u"қ": u"q", 
+    u"Ӯ": u"Ū", u"ӯ": u"ū",
+    u"Ҳ": u"H", u"ҳ": u"h",
+    u"Ҷ": u"Ç", u"ҷ": u"ç"
+})
+
+# transliterate from latin tajik to cyrillic
+TJ_LAT_TO_CYR_DICT = {y: x for x, y in iter(TJ_CYR_TO_LAT_DICT.items())}
+
+# care for latin digraphs
+#TJ_LAT_TO_CYR_DICT.update(RU_LAT_TO_CYR_DICT)
+
 # Bundle up all the dictionaries in a lookup dictionary
 TRANSLIT_DICT = {
     'sr': { # Serbia
@@ -151,5 +173,9 @@ TRANSLIT_DICT = {
     'ru': { # Russian
         'tolatin': RU_CYR_TO_LAT_DICT,
         'tocyrillic': RU_LAT_TO_CYR_DICT
+    },
+    'tj': { # Tajik
+        'tolatin': TJ_CYR_TO_LAT_DICT,
+        'tocyrillic': TJ_LAT_TO_CYR_DICT
     },
 }

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -16,7 +16,7 @@ What is CyrTranslit?
 ====================
 A Python package for bi-directional transliteration of Cyrillic script text into Roman alphabet text and vice versa.
 
-By default, transliterates for the Serbian language. A language flag can be set in order to transliterate to and from Macedonian, Montenegrin, and Russian.
+By default, transliterates for the Serbian language. A language flag can be set in order to transliterate to and from Macedonian, Montenegrin, Tajik and Russian.
 
 ========================
 What is transliteration?
@@ -42,11 +42,11 @@ Minimum version:
 =============================
 What languages are supported?
 =============================
-CyrTranslit currently supports bi-directional transliteration of Montenegrin, Serbian, Macedonian, and Russian:
+CyrTranslit currently supports bi-directional transliteration of Montenegrin, Serbian, Macedonian, Tajik and Russian:
 
 >>> import cyrtranslit
 >>> cyrtranslit.supported()
-['me', 'sr', 'mk', 'ru']``
+['me', 'sr', 'mk', 'tj', 'ru']``
 
 
 ==================
@@ -88,6 +88,15 @@ Russian
 'Moyo sudno na vozdushnoj podushke polno ugrej'
 >>> cyrtranslit.to_cyrillic('Moyo sudno na vozdushnoj podushke polno ugrej', 'ru')
 'Моё судно на воздушной подушке полно угрей'
+
+*****
+Tajik
+*****
+>>> import cyrtranslit
+>>> cyrtranslit.to_latin('Ман мактуб навишта истодам', 'tj')
+'Man maktub navišta istodam'
+>>> cyrtranslit.to_cyrillic('Man maktub navišta istodam', 'tj')
+'Ман мактуб навишта истодам'
 
 
 =====================

--- a/tests.py
+++ b/tests.py
@@ -15,6 +15,9 @@ macedonian_alphabet_latin = 'AaBbVvGgDdǴǵEeŽžZzDzdzIiJjKkLlLjljMmNnNjnjOoPpR
 russian_alphabet_cyrillic = 'АаБбВвГгДдЕеЁёЖжЗзИиЙйКкЛлМмНнОоПпРрСсТтУуФфХхЦцЧчШшЩщЪъЫыЬьЭэЮюЯя'
 russian_alphabet_latin = 'AaBbVvGgDdEeYOyoZHzhZzIiJjKkLlMmNnOoPpRrSsTtUuFfHhCcCHchSHshSZsz##Yy\'\'EHehJUjuJAja'
 
+tajik_alphabet_cyrillic = 'АаБбВвГгҒғДдЕеЁёЖжЗзИиӢӣЙйКкЛлМмНнОоПпРрСсТтУуӮӯФфХхҲҳЧчҶҷШшЪъЭэЮюЯя'
+tajik_alphabet_latin = 'AaBbVvGgǦǧDdEeYOyoZHzhZzIiĪīJjKkLlMmNnOoPpRrSsTtUuŪūFfHhHhCHchÇçSHsh\'\'EeJUjuJAja'
+
 special_chars = '‘’‚“”„†‡‰‹›♠♣♥♦‾←↑→↓™!"#$%&\'()*+,-./ :;<=>?@[\\]^_`{|}~…–—¡¢£¤¥¦§¨©ª«¬®¯°±²³´µ¶·¸¹º»¼½¾¿×'
 
 diacritic_chars = 'ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝàáâãäåæçèéêëìíîïðñòóôõöøùúûüý'
@@ -171,6 +174,18 @@ class TestRussianTransliteration(unittest.TestCase):
 
         self.assertEqual(transliterated_alphabet, russian_alphabet_cyrillic.replace('Ъ', 'ъ').replace('Ь', 'ь'))
 
+class TestTajikTransliteration(unittest.TestCase):
+    def test_alphabet_transliteration_cyrillic_to_latin(self):
+        ''' Transliterate the entire cyrillic alphabet to latin '''
+        transliterated_alphabet = cyrtranslit.to_latin(tajik_alphabet_cyrillic, lang_code='tj')
+
+        self.assertEqual(transliterated_alphabet, tajik_alphabet_latin)
+
+    def test_alphabet_transliteration_latin_to_cyrillic(self):
+        ''' Transliterate the entire latin alphabet to cyrillic '''
+        transliterated_alphabet = cyrtranslit.to_cyrillic(tajik_alphabet_latin, lang_code='tj')
+
+        self.assertEqual(transliterated_alphabet, tajik_alphabet_cyrillic)
 
 if __name__ == '__main__':
     # Run all tests.

--- a/tests.py
+++ b/tests.py
@@ -15,8 +15,8 @@ macedonian_alphabet_latin = 'AaBbVvGgDdǴǵEeŽžZzDzdzIiJjKkLlLjljMmNnNjnjOoPpR
 russian_alphabet_cyrillic = 'АаБбВвГгДдЕеЁёЖжЗзИиЙйКкЛлМмНнОоПпРрСсТтУуФфХхЦцЧчШшЩщЪъЫыЬьЭэЮюЯя'
 russian_alphabet_latin = 'AaBbVvGgDdEeYOyoZHzhZzIiJjKkLlMmNnOoPpRrSsTtUuFfHhCcCHchSHshSZsz##Yy\'\'EHehJUjuJAja'
 
-tajik_alphabet_cyrillic = 'АаБбВвГгҒғДдЕеЁёЖжЗзИиӢӣЙйКкЛлМмНнОоПпРрСсТтУуӮӯФфХхҲҳЧчҶҷШшЪъЭэЮюЯя'
-tajik_alphabet_latin = 'AaBbVvGgǦǧDdEeYOyoZHzhZzIiĪīJjKkLlMmNnOoPpRrSsTtUuŪūFfHhHhCHchÇçSHsh\'\'EeJUjuJAja'
+tajik_alphabet_cyrillic = 'АаБбВвГгҒғДдЕеЁёЖжЗзИиӢӣЙйКкЛлМмНнОоПпРрСсТтУуӮӯФфХхҲҳЧчҶҷШшъЭэЮюЯя'
+tajik_alphabet_latin = 'AaBbVvGgǦǧDdEeËëŽžZzIiĪīJjKkLlMmNnOoPpRrSsTtUuŪūFfHhḨḩČčÇçŠš’ÈèÛûÂâ'
 
 special_chars = '‘’‚“”„†‡‰‹›♠♣♥♦‾←↑→↓™!"#$%&\'()*+,-./ :;<=>?@[\\]^_`{|}~…–—¡¢£¤¥¦§¨©ª«¬®¯°±²³´µ¶·¸¹º»¼½¾¿×'
 
@@ -186,6 +186,22 @@ class TestTajikTransliteration(unittest.TestCase):
         transliterated_alphabet = cyrtranslit.to_cyrillic(tajik_alphabet_latin, lang_code='tj')
 
         self.assertEqual(transliterated_alphabet, tajik_alphabet_cyrillic)
+
+    def test_special_diacritic_characters(self):
+        ''' Diacritic characters should remain the same.
+        '''
+        transliterated_diacritic_chars = cyrtranslit.to_latin(diacritic_chars, lang_code='tj')
+
+        self.assertEqual(transliterated_diacritic_chars, diacritic_chars)
+
+
+    def test_numerical_characters(self):
+        ''' Numerical characters should remain the same.
+        '''
+        transliterated_numerical_chars = cyrtranslit.to_latin(numerical_chars, lang_code='tj')
+
+        self.assertEqual(transliterated_numerical_chars, numerical_chars)
+
 
 if __name__ == '__main__':
     # Run all tests.


### PR DESCRIPTION
I added the Tajik cyrillic alphabet. I changed the mappings according to ISO 9 (1999), using the table on the Wikipedia Page about the Tajik alphabet (https://en.wikipedia.org/wiki/Tajik_alphabet#Transliteration_standards).