### PR TITLE
Declare that cyrtranslit supports Python 3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,5 +21,6 @@ setup(
                'Programming Language :: Python :: 3.3',
                'Programming Language :: Python :: 3.4',
                'Programming Language :: Python :: 3.5',
-               'Programming Language :: Python :: 3.6'],
+               'Programming Language :: Python :: 3.6',
+               'Programming Language :: Python :: 3.7'],
 )


### PR DESCRIPTION
We succesfully use cyrtranslit in our projects which use Python 3.7 mostly.

I think it could be nice to declare that this lib supports py 3.7. Current tests pass on py 3.7.