### PR TITLE
Ignore missing "t" after "sh" in BG cyrillic transliteration

### DIFF
--- a/cyrtranslit/__init__.py
+++ b/cyrtranslit/__init__.py
@@ -146,15 +146,18 @@ def to_cyrillic(string_to_transliterate, lang_code='sr'):
 
                 # In Bulgarian, the letter "щ" is represented by three latin letters: "sht", 
                 # so we need this logic to support the third latin letter
-                try:
-                    if (lang_code == 'bg' and (c == 'sh' or c == 'Sh' or c == 'SH') and string_to_transliterate[index + 1] in u'Tt'):
-                        index += 1
-                        c += string_to_transliterate[index]
-                except IndexError:
-                    pass  # Ignore
+                if lang_code == 'bg' and \
+                        index + 2 <= length_of_string_to_transliterate - 1 and \
+                        (c == 'sh' or c == 'Sh' or c == 'SH') and \
+                        string_to_transliterate[index + 1] in u'Tt':
+                    index += 1
+                    c += string_to_transliterate[index]
                     
                 # Similarly in Russian, the letter "щ" шы represented by "shh".
-                if lang_code == 'ru' and index + 2 <= length_of_string_to_transliterate - 1 and (c == u'sh' or c == 'Sh' or c == 'SH') and string_to_transliterate[index + 1] in u'Hh':  # shh
+                if lang_code == 'ru' and \
+                        index + 2 <= length_of_string_to_transliterate - 1 and \
+                        (c == u'sh' or c == 'Sh' or c == 'SH') and \
+                        string_to_transliterate[index + 1] in u'Hh':  # shh
                     index += 1
                     c += string_to_transliterate[index]
 

--- a/cyrtranslit/__init__.py
+++ b/cyrtranslit/__init__.py
@@ -146,9 +146,12 @@ def to_cyrillic(string_to_transliterate, lang_code='sr'):
 
                 # In Bulgarian, the letter "щ" is represented by three latin letters: "sht", 
                 # so we need this logic to support the third latin letter
-                if (lang_code == 'bg' and (c == 'sh' or c == 'Sh' or c == 'SH') and string_to_transliterate[index + 1] in u'Tt'):
-                    index += 1
-                    c += string_to_transliterate[index]
+                try:
+                    if (lang_code == 'bg' and (c == 'sh' or c == 'Sh' or c == 'SH') and string_to_transliterate[index + 1] in u'Tt'):
+                        index += 1
+                        c += string_to_transliterate[index]
+                except IndexError:
+                    pass  # Ignore
                     
                 # Similarly in Russian, the letter "щ" шы represented by "shh".
                 if lang_code == 'ru' and index + 2 <= length_of_string_to_transliterate - 1 and (c == u'sh' or c == 'Sh' or c == 'SH') and string_to_transliterate[index + 1] in u'Hh':  # shh

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from pathlib import Path
 setup(
   name='cyrtranslit',
   packages=['cyrtranslit'],
-  version='1.1',
+  version='1.1.1',
   description='Bi-directional Cyrillic transliteration. Transliterate Cyrillic script to Latin script and vice versa. Supports transliteration for Bulgarian, Montenegrin, Macedonian, Mongolian, Russian, Serbian, Tajik, and Ukrainian.',
   long_description=(Path(__file__).parent / "README.md").read_text(),
   long_description_content_type='text/markdown',

--- a/tests.py
+++ b/tests.py
@@ -240,6 +240,12 @@ class TestBulgarianTransliteration(unittest.TestCase):
 
         self.assertEqual(transliterated_alphabet, bulgarian_alphabet_cyrillic)
 
+    def test_sh_at_the_end_of_string(self):
+        ''' Check if "sh" at the of the string doesn't cause any exception.'''
+        transliterated_alphabet = cyrtranslit.to_cyrillic("AaBbsh", lang_code='bg')
+
+        self.assertEqual(transliterated_alphabet, "АаБбш")
+
 
 class TestMongolianTransliterationFromCyrillicToLatin(unittest.TestCase):
 


### PR DESCRIPTION
Hey guys,

we got the English term "mesh" for transliteration at the end of the string and it caused an exception because there is no word after the "sh". (IndexError). So I'd ignore it. 